### PR TITLE
User Can Comment on An Article

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'rails', '~> 6.0.2'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.7'
 gem 'rack-cors', require: 'rack/cors'
+gem 'devise_token_auth'
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    bcrypt (3.1.13)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -69,6 +70,16 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.6)
+    devise (4.7.1)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise_token_auth (1.1.3)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 6.1)
     diff-lcs (1.3)
     docile (1.3.2)
     erubi (1.9.0)
@@ -102,6 +113,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -147,6 +159,9 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.1)
@@ -191,6 +206,8 @@ GEM
       sync
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    warden (1.2.8)
+      rack (>= 2.0.6)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -202,6 +219,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.2)
   coveralls
+  devise_token_auth
   factory_bot_rails
   listen (~> 3.0.5)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,0 +1,4 @@
+class Api::CommentsController < ApplicationController
+  def create
+  end
+end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,4 +1,6 @@
 class Api::CommentsController < ApplicationController
   def create
+    comment = Comment.create()
+    render json: { message: 'Your comment has been created' }
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+        include DeviseTokenAuth::Concerns::SetUserByToken
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,4 @@
 class Article < ApplicationRecord
   validates_presence_of :title, :body
+  has_many :comments
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,3 @@
+class Comment < ApplicationRecord
+  belongs_to :article
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,4 @@
 class Comment < ApplicationRecord
   belongs_to :article
+  validates_presence_of :body
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,7 @@
+class User < ActiveRecord::Base
+  extend Devise::Models
+  
+  devise :database_authenticatable, :registerable,
+          :recoverable, :rememberable, :trackable, :validatable
+  include DeviseTokenAuth::Concerns::User
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   namespace :api do
     resources :articles, only: [:index, :show]
+    resources :comments, only: [:create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount_devise_token_auth_for 'User', at: 'auth', skip: [:omniauth_callbacks]
   namespace :api do
     resources :articles, only: [:index, :show]
     resources :comments, only: [:create]

--- a/db/migrate/20200422131626_create_comments.rb
+++ b/db/migrate/20200422131626_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.string :commenter
+      t.text :body
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200422131626_create_comments.rb
+++ b/db/migrate/20200422131626_create_comments.rb
@@ -1,9 +1,9 @@
 class CreateComments < ActiveRecord::Migration[6.0]
   def change
     create_table :comments do |t|
-      t.string :commenter
+
       t.text :body
-      t.references :article, null: false, foreign_key: true
+      t.references :article
 
       t.timestamps
     end

--- a/db/migrate/20200422141818_devise_token_auth_create_users.rb
+++ b/db/migrate/20200422141818_devise_token_auth_create_users.rb
@@ -1,0 +1,50 @@
+class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    
+    create_table(:users) do |t|
+      ## Required
+      t.string :provider, :null => false, :default => "email"
+      t.string :uid, :null => false, :default => ""
+
+      ## Database authenticatable
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+      t.integer :sign_in_count, default: 0
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :email
+
+      ## Tokens
+      t.json :tokens
+
+      t.timestamps
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, [:uid, :provider],     unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,       unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_22_131626) do
+ActiveRecord::Schema.define(version: 2020_04_22_141818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,33 @@ ActiveRecord::Schema.define(version: 2020_04_22_131626) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["article_id"], name: "index_comments_on_article_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "email"
+    t.json "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
   add_foreign_key "comments", "articles"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_22_063446) do
+ActiveRecord::Schema.define(version: 2020_04_22_131626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,4 +22,14 @@ ActiveRecord::Schema.define(version: 2020_04_22_063446) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.string "commenter"
+    t.text "body"
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_comments_on_article_id"
+  end
+
+  add_foreign_key "comments", "articles"
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    commenter { "MyString" }
+    body { "MyText" }
+    article { nil }
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :comment do
     body { "Your comment has been created" }
+    association :article, factory: :article
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
   factory :comment do
-    commenter { "MyString" }
-    body { "MyText" }
-    article { nil }
+    body { "Your comment has been created" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    email { "user@mail.com" }
+    password { "password" }
+    password_confirmation { "password" }
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,5 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "Commentss has db columns" do
+    it { is_expected.to have_db_column :body }
+  end
+
+  describe "Validations" do
+    it { is_expected.to validate_presence_of :body }
+  end
+
+  describe "Factory" do
+    it "Should have valid factory" do
+      expect(create(:comment)).to be_valid
+    end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Comment, type: :model do
-  describe "Commentss has db columns" do
+  describe "Comments has db columns" do
     it { is_expected.to have_db_column :body }
+    it { is_expected.to belong_to :article }
   end
 
   describe "Validations" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it 'should have valid Factory' do
+    expect(create(:user)).to be_valid
+  end
+  describe 'Database table' do
+    it { is_expected.to have_db_column :encrypted_password }
+    it { is_expected.to have_db_column :email }
+    it { is_expected.to have_db_column :tokens }
+  end
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :email }
+    it { is_expected.to validate_confirmation_of :password }
+
+    context 'should not have an invalid email address' do
+      emails = ['asdf@ ds.com', '@example.com', 'test me @yahoo.com',
+                'asdf@example', 'ddd@.d. .d', 'ddd@.d']
+
+      emails.each do |email|
+        it { is_expected.not_to allow_value(email).for(:email) }
+      end
+    end
+
+    context 'should have a valid email address' do
+      emails = ['asdf@ds.com', 'hello@example.uk', 'test1234@yahoo.si',
+                'asdf@example.eu']
+
+      emails.each do |email|
+        it { is_expected.to allow_value(email).for(:email) }
+      end
+    end
+  end
+end

--- a/spec/requests/api/comments/user_can_comment.spec.rb
+++ b/spec/requests/api/comments/user_can_comment.spec.rb
@@ -2,9 +2,8 @@ RSpec.describe 'POST /api/comment', type: :request do
   let!(:article) { create(:article) }
   
   describe 'successfully creates comment' do
-    let!(:comment) { create(:comment)}
     before do 
-      post '/api/comment'
+      post '/api/comments'
     end
 
     it 'returns a 200 response' do

--- a/spec/requests/api/comments/user_can_comment.spec.rb
+++ b/spec/requests/api/comments/user_can_comment.spec.rb
@@ -1,16 +1,25 @@
 RSpec.describe 'POST /api/comment', type: :request do
-  let!(:article) { create(:article) }
-  
+  describe 'valid credentials input' do
+    let(:user) { create(:user) }
+    let(:user_credentials) { user.create_new_auth_token }
+  end
   describe 'successfully creates comment' do
+
+    let!(:article) { create(:article) }
     before do 
-      post '/api/comments'
+      post '/api/comments',
+      params: {
+        comment: {
+          body: 'you created a comment'
+        }
+      }
     end
 
     it 'returns a 200 response' do
       expect(response).to have_http_status 200
     end
 
-    it 'returns three articles' do
+    it 'returns a successful response message' do
       expect(response_json['message']).to eq 'Your comment has been created'
     end
   end

--- a/spec/requests/api/comments/user_can_comment.spec.rb
+++ b/spec/requests/api/comments/user_can_comment.spec.rb
@@ -1,8 +1,10 @@
 RSpec.describe 'POST /api/comment', type: :request do
-  let!(:articles) { 3.times { create(:article) } }
-  describe 'successfully' do
-    before do
-      POST '/api/comment'
+  let!(:article) { create(:article) }
+  
+  describe 'successfully creates comment' do
+    let!(:comment) { create(:comment)}
+    before do 
+      post '/api/comment'
     end
 
     it 'returns a 200 response' do

--- a/spec/requests/api/comments/user_can_comment.spec.rb
+++ b/spec/requests/api/comments/user_can_comment.spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe 'POST /api/comment', type: :request do
+  let!(:articles) { 3.times { create(:article) } }
+  describe 'successfully' do
+    before do
+      POST '/api/comment'
+    end
+
+    it 'returns a 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'returns three articles' do
+      expect(response_json['message']).to eq "Your comment has been created"
+    end
+  end
+end

--- a/spec/requests/api/comments/user_can_comment.spec.rb
+++ b/spec/requests/api/comments/user_can_comment.spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'POST /api/comment', type: :request do
     end
 
     it 'returns three articles' do
-      expect(response_json['message']).to eq "Your comment has been created"
+      expect(response_json['message']).to eq 'Your comment has been created'
     end
   end
 end

--- a/spec/requests/api/comments_request_spec.rb
+++ b/spec/requests/api/comments_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Comments", type: :request do
+
+end


### PR DESCRIPTION
```
As a User
In order to voice my opinion on an article
I would like to be able to leave a comment
```
## Changes proposed in this pull request:
 *Write request spec
 *Add comment model
 *Comment needs to contain a body
 *Add association between comment and article
 *Only authenticated user can comment, add user model with devise token auth
 *Add association between comment and user

## Packages/Gems added
- devise_token_auth