### PR TITLE
Article comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'rails', '~> 6.0.2'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.7'
 gem 'rack-cors', require: 'rack/cors'
+gem 'devise_token_auth'
+
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    bcrypt (3.1.13)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -69,6 +70,16 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.6)
+    devise (4.7.1)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise_token_auth (1.1.3)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 6.1)
     diff-lcs (1.3)
     docile (1.3.2)
     erubi (1.9.0)
@@ -102,6 +113,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -147,6 +159,9 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.1)
@@ -191,6 +206,8 @@ GEM
       sync
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    warden (1.2.8)
+      rack (>= 2.0.6)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -202,6 +219,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.2)
   coveralls
+  devise_token_auth
   factory_bot_rails
   listen (~> 3.0.5)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,0 +1,20 @@
+class Api::CommentsController < ApplicationController
+    before_action :authenticate_user!, only: %i[create]
+    
+    def create
+        if user.role == 'commenter'
+            comment = Comment.create(comment_params)
+            render json: {message: "Your comment has been added"}
+        else
+            render json: {error: "Something went wrong"},
+            status: 422
+        end
+    end
+
+
+    private
+
+    def comment_params
+        params.require(:comment).permit(:title, :body)
+    end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::API
+        include DeviseTokenAuth::Concerns::SetUserByToken
+
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,4 @@
 class Article < ApplicationRecord
   validates_presence_of :title, :body
+  has_many :comments
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,3 @@
+class Comment < ApplicationRecord
+  belongs_to :article
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class User < ActiveRecord::Base
+  extend Devise::Models
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+  include DeviseTokenAuth::Concerns::User
+  validates_presence_of :role
+  enum role: [:user, :commenter]
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
+  mount_devise_token_auth_for 'User', at: 'auth'
   namespace :api do
     resources :articles, only: [:index, :show]
+    resources :comments, only: [:create]
   end
 end

--- a/db/migrate/20200422120856_create_comments.rb
+++ b/db/migrate/20200422120856_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.string :commenter
+      t.text :body
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200422140953_devise_token_auth_create_users.rb
+++ b/db/migrate/20200422140953_devise_token_auth_create_users.rb
@@ -1,0 +1,49 @@
+class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    
+    create_table(:users) do |t|
+      ## Required
+      t.string :provider, :null => false, :default => "email"
+      t.string :uid, :null => false, :default => ""
+
+      ## Database authenticatable
+      t.string :encrypted_password, :null => false, :default => ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, :default => false
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :name
+      t.string :nickname
+      t.string :image
+      t.string :email
+
+      ## Tokens
+      t.json :tokens
+
+      t.timestamps
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, [:uid, :provider],     unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,       unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_22_063446) do
+ActiveRecord::Schema.define(version: 2020_04_22_140953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,4 +22,39 @@ ActiveRecord::Schema.define(version: 2020_04_22_063446) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.string "commenter"
+    t.text "body"
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_comments_on_article_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "nickname"
+    t.string "image"
+    t.string "email"
+    t.json "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+  end
+
+  add_foreign_key "comments", "articles"
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :comment do
+    commenter { "MyString" }
+    title {'Comment title'}
+    body { "MyText" }
+    association :article, factory: :article
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :user do
+    email { "MyString" }
+    password { "MyString" }
+    password_confirmation { "MyString" }
+    role { 'user'}
+    factory :commenter do
+      role {'commenter'}
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  describe "Comment has db columns" do
+    it { is_expected.to have_db_column :title }
+    it { is_expected.to have_db_column :body }
+  end
+
+  describe "Validations" do
+    it { is_expected.to validate_presence_of :title }
+    it { is_expected.to validate_presence_of :body }
+  end
+
+  describe "Factory" do
+    it "Should have valid factory" do
+      expect(create(:article)).to be_valid
+    end
+  end
+end

--- a/spec/requests/api/comments/user_can_comment_article_spec.rb
+++ b/spec/requests/api/comments/user_can_comment_article_spec.rb
@@ -1,11 +1,37 @@
 RSpec.describe 'POST /api/comments', type: :request do
-  let!(:articles) { 3.times { create(:article) } }
+  let!(:articles) { create(:article) }
+
+  let(:user) { create(:user, role: 'user') }
+  let(:user_credentials) { user.create_new_auth_token }
+  let(:user_headers) do
+    { HTTP_ACCEPT: "application/json" }.merge!(user_credentials)
+  end
+
+  let(:commenter) { create(:user, role: 'commenter') }
+  let(:commenter_credentials) { commenter.create_new_auth_token }
+  let(:commenter_headers) do 
+    { HTTP_ACCEPT: "application/json" }.merge!(commenter_credentials)
+  end
+
   describe 'successfully' do
     before do
-      post '/api/comments'
+      post '/api/comments',
+      params:{
+        comment:{
+          title: 'New Comment',
+          body: "Comment body",
+        },
+      },
+      headers: commenter_headers
     end
+    
     it 'returns a 200 response' do
       expect(response).to have_http_status 200
     end
+
+    it 'returns a response' do
+      expect(response_json['message']).to eq "Your comment has been added"
+    end
+    
   end
 end

--- a/spec/requests/api/comments/user_can_comment_article_spec.rb
+++ b/spec/requests/api/comments/user_can_comment_article_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe 'POST /api/comments', type: :request do
+  let!(:articles) { 3.times { create(:article) } }
+  describe 'successfully' do
+    before do
+      post '/api/comments'
+    end
+    it 'returns a 200 response' do
+      expect(response).to have_http_status 200
+    end
+  end
+end

--- a/spec/requests/api/comments_request_spec.rb
+++ b/spec/requests/api/comments_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Comments", type: :request do
+
+end

--- a/spec/requests/comments_request_spec.rb
+++ b/spec/requests/comments_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Comments", type: :request do
+
+end


### PR DESCRIPTION
# [PT Story]
```
As a user 
In order to comment an article
I would like the to be able to add a comment 
```
## Changes proposed in this pull request:
* Adds request spec user can add a comment 
* Installs and setups Devise Token Auth

## What I have learned working on this feature:
* Modifying request spec and Factory Bots
* Refreshed knowledge about implementing Devise Token Auth

## Packages/Gems added
- devise-token-auth

